### PR TITLE
charts/watchman: Configurable liveness/readiness

### DIFF
--- a/stable/watchman/templates/deployment.yaml
+++ b/stable/watchman/templates/deployment.yaml
@@ -96,10 +96,18 @@ spec:
               name: admin
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             httpGet:
               path: /ping
               port: http
           readinessProbe:
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             httpGet:
               path: /ping
               port: http

--- a/stable/watchman/values.yaml
+++ b/stable/watchman/values.yaml
@@ -97,11 +97,23 @@ resources: {}
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
+  #   cpu: 200m
+  #   memory: 400Mi
   # requests:
   #   cpu: 100m
-  #   memory: 128Mi
+  #   memory: 200Mi
+
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 5
+
+readinessProbe: 
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 5
 
 nodeSelector: {}
 


### PR DESCRIPTION
I'm not a regular OSS contributor, so please let me know if you'd like anything done differently

Resolves https://github.com/moov-io/charts/issues/32

Also updated commented resource specs to reflect observed successful specs from https://github.com/moov-io/infra/commit/a50b0b42b390a44dbd1934720787649eaae95b5b